### PR TITLE
Update TOC fields for 11.0.0

### DIFF
--- a/grammars/toc.tmLanguage.json
+++ b/grammars/toc.tmLanguage.json
@@ -24,7 +24,7 @@
               "name": "entity.name.tag.localized.toc"
             },
             {
-              "match": "(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc|AddonCompartmentFuncOnEnter|AddonCompartmentFuncOnLeave|IconTexture|IconAtlas)",
+              "match": "(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc(OnEnter|OnLeave)?|IconTexture|IconAtlas)",
               "name": "entity.name.tag.toc"
             },
             {

--- a/grammars/toc.tmLanguage.json
+++ b/grammars/toc.tmLanguage.json
@@ -28,7 +28,7 @@
               "name": "entity.name.tag.toc"
             },
             {
-              "match": "(?i)(AllowLoad|OnlyBetaAndPTR|SavedVariablesMachine|Secure|GuardedAddOn)",
+              "match": "(?i)(AllowLoad(GameType)?|OnlyBetaAndPTR|SavedVariablesMachine|Secure|LoadFirst|UseSecureEnvironment)",
               "name": "entity.name.tag.restricted.toc"
             },
             {


### PR DESCRIPTION
I'll be lazy and just copy/paste what I said for nebularg/language-toc-wow#4.

---

This adds the new secure fields that Blizzard added through patches 10.2.6 to 11.0.0:

- AllowLoadGameType
- UseSecureEnvironment
- LoadFirst (renamed from GuardedAddOn).

I've omitted the AllowLoadByGameMode and SuppressLocalTableRef fields. These were added in 10.2.6 and 10.2.7, but both were removed one patch later and aren't present in Mainline. In terms of Classic clients, these fields also won't exist there either come patches 1.15.4 and 4.4.1 in the next few weeks.

I've also fixed highlighting of the "AddonCompartmentFuncOnEnter" and "AddonCompartmentFuncOnLeave" fields; both of these would terminate their match at "AddonCompartmentFunc" and leave the rest of the token unmatched. Now the OnEnter and OnLeave portions should be picked up and highlighted if present.

---

Bonus screenshot to prove all of the above changes work:

![image](https://github.com/user-attachments/assets/d83b07ea-4487-46f6-ab58-7f16595ebf55)

