### PR TITLE
Update TOC fields for 11.1.0

### DIFF
--- a/grammars/toc.tmLanguage.json
+++ b/grammars/toc.tmLanguage.json
@@ -20,11 +20,11 @@
               "name": "entity.name.tag.custom.toc"
             },
             {
-              "match": "(?i)(Title-|Notes-|)(?-i)(deDE|enCN|enGB|enTW|enUS|esES|esMX|frFR|itIT|ptBR|ptPT|ruRU|koKR|zhTW|zhCN)",
+              "match": "(?i)(Title-|Notes-|Category-|)(?-i)(enUS|enCN|enGB|enTW|frFR|deDE|esES|esMX|itIT|ptBR|ptPT|ruRU|koKR|zhTW|zhCN)",
               "name": "entity.name.tag.localized.toc"
             },
             {
-              "match": "(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc(OnEnter|OnLeave)?|IconTexture|IconAtlas)",
+              "match": "(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc(OnEnter|OnLeave)?|IconAtlas|IconTexture|Category|Group)",
               "name": "entity.name.tag.toc"
             },
             {


### PR DESCRIPTION
Patch 11.1.0 is adding two new TOC fields for use in the improved addon list - Category and Group.

Technically both of these fields support localized variants, but of the two only Category is ever shown in the UI and Group is just an arbitrary "tag" of sorts that isn't displayed. As such, I'll pretend that `## Group-deDE: Foo` isn't a thing and won't consider it a valid token.

I also note that for some reason the order of a few extra matches differs from what's in nebularg/language-toc-wow - might as well make them consistent as they're both the same thing in the end.