### PR TITLE
Update grammar for 11.1.5

### DIFF
--- a/grammars/toc.tmLanguage.json
+++ b/grammars/toc.tmLanguage.json
@@ -71,6 +71,56 @@
       "name": "comment.toc"
     },
     {
+      "name": "entity.name.file.toc",
+      "begin": "^(?!#)\\s*(?=[\\w\\[])",
+      "end": "\\n",
+      "patterns": [
+        {
+          "include": "#inline-conditional-directive"
+        },
+        {
+          "include": "#inline-variable-directive"
+        }
+      ]
+    },
+    {
+      "match": "@.*?@",
+      "name": "constant.other.packager.toc"
+    }
+  ],
+  "repository": {
+    "inline-conditional-directive": {
+      "comment": "Inline file-specific conditional loading directive using [Directive ...]",
+      "match": "\\[(\\w+)(\\s+)([^\\]]*)\\]",
+      "name": "keyword.tag.toc",
+      "captures": {
+        "1": {
+          "name": "keyword.tag.toc",
+          "patterns": [
+            {
+              "match": "(?i)(AllowLoadGameType)",
+              "name": "entity.name.tag.toc"
+            },
+            {
+              "match": "(?i)(AllowLoad)",
+              "name": "entity.name.tag.restricted.toc"
+            },
+            {
+              "match": ".+",
+              "name": "invalid.tag.toc"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.key-value"
+        },
+        "3": {
+          "name": "string.escape.coloring.toc"
+        }
+      }
+    },
+    "inline-variable-directive": {
+      "comment": "Inline variable expansion using [...]",
       "match": "\\[(\\w+)\\]",
       "name": "keyword.tag.toc",
       "captures": {
@@ -88,47 +138,6 @@
           ]
         }
       }
-    },
-    {
-      "match": "\\[(\\w+)(\\s+)([^\\]]*)\\]",
-      "name": "keyword.tag.toc",
-      "captures": {
-        "1": {
-          "name": "keyword.tag.toc",
-          "patterns": [
-            {
-              "match": "(?i)(AllowLoadGameType)",
-              "name": "entity.name.tag.toc"
-            },
-            {
-              "match": "(?i)(AllowLoad)",
-              "name": "entity.name.tag.restricted.toc"
-            },
-            {
-              "match": "\\S[^:]+",
-              "name": "invalid.tag.toc"
-            }
-          ]
-        },
-        "2": {
-          "name": "punctuation.separator.key-value"
-        },
-        "3": {
-          "name": "string.escape.coloring.toc"
-        }
-      }
-    },
-    {
-      "match": "^(?!#)\\s*[^ ].+\\.xml",
-      "name": "meta.require.xml.toc"
-    },
-    {
-      "match": "^(?!#)\\s*[^ ].+\\.lua",
-      "name": "meta.require.lua.toc"
-    },
-    {
-      "match": "@.*?@",
-      "name": "constant.other.packager.toc"
     }
-  ]
+  }
 }

--- a/grammars/toc.tmLanguage.json
+++ b/grammars/toc.tmLanguage.json
@@ -24,11 +24,11 @@
               "name": "entity.name.tag.localized.toc"
             },
             {
-              "match": "(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|SavedVariablesPerCharacter|SavedVariables|DefaultState|Author|Version|AddonCompartmentFunc(OnEnter|OnLeave)?|IconAtlas|IconTexture|Category|Group)",
+              "match": "(?i)(Interface|Title|Notes|RequiredDeps|\\bDep[^:]*|OptionalDeps|LoadOnDemand|LoadWith|LoadManagers|AllowLoadGameType|SavedVariablesPerCharacter|SavedVariables|LoadSavedVariablesFirst|DefaultState|Author|Version|AddonCompartmentFunc(OnEnter|OnLeave)?|IconAtlas|IconTexture|Category|Group)",
               "name": "entity.name.tag.toc"
             },
             {
-              "match": "(?i)(AllowLoad(GameType)?|OnlyBetaAndPTR|SavedVariablesMachine|Secure|LoadFirst|UseSecureEnvironment)",
+              "match": "(?i)(AllowLoad|OnlyBetaAndPTR|SavedVariablesMachine|Secure|LoadFirst|UseSecureEnvironment)",
               "name": "entity.name.tag.restricted.toc"
             },
             {
@@ -71,8 +71,60 @@
       "name": "comment.toc"
     },
     {
-      "match": "^(?!#)[^ ].+\\.xml",
+      "match": "\\[(\\w+)\\]",
+      "name": "keyword.tag.toc",
+      "captures": {
+        "1": {
+          "name": "keyword.tag.toc",
+          "patterns": [
+            {
+              "match": "(?i)(Family|Game)",
+              "name": "entity.name.tag.variable.toc"
+            },
+            {
+              "match": "\\S[^:]+",
+              "name": "invalid.tag.toc"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "match": "\\[(\\w+)(\\s+)([^\\]]*)\\]",
+      "name": "keyword.tag.toc",
+      "captures": {
+        "1": {
+          "name": "keyword.tag.toc",
+          "patterns": [
+            {
+              "match": "(?i)(AllowLoadGameType)",
+              "name": "entity.name.tag.toc"
+            },
+            {
+              "match": "(?i)(AllowLoad)",
+              "name": "entity.name.tag.restricted.toc"
+            },
+            {
+              "match": "\\S[^:]+",
+              "name": "invalid.tag.toc"
+            }
+          ]
+        },
+        "2": {
+          "name": "punctuation.separator.key-value"
+        },
+        "3": {
+          "name": "string.escape.coloring.toc"
+        }
+      }
+    },
+    {
+      "match": "^(?!#)\\s*[^ ].+\\.xml",
       "name": "meta.require.xml.toc"
+    },
+    {
+      "match": "^(?!#)\\s*[^ ].+\\.lua",
+      "name": "meta.require.lua.toc"
     },
     {
       "match": "@.*?@",


### PR DESCRIPTION
Update the TOC grammar for 11.1.5 with support for the following:

- Inline block support for `[Variable]` expansions and `[AllowLoad foo, bar]` conditions.
- Add the LoadSavedVariablesFirst directive.
- Mark AllowLoadGameType as a regular directive as it's now usable by addons.

Test case:

```toc
## Interface: 110105
## Title: My Cool Addon
## Title-deDE: Mein Kool Addon
## LoadSavedVariablesFirst: 1
## LoadSavedVariablesSecond: no
## AllowLoad: glue
## AllowLoadGameType: plunderstorm

# Commented line
BasicFile.xml
  # Indented commented line
  IndentedFile.lua [AllowLoad glue]
  IndentedFile\[Family].lua

[Family].lua
[Game].xml
Subdirectory\[Game]\[Family]\[Game]\[Family]\File.xml

[Family].lua [AllowLoad glue]
[Game].xml [AllowLoadGameType vanilla, cata]
Subdirectory\[Game]\[Family]\[Game]\[Family]\File.xml [AllowLoad glue] [AllowLoadGameType vanilla, cata]

[InvalidVariable].lua
ValidFileWithInvalidCondition [PotatoMode test]
ValidFileWithInvalidCondition [PotatoMode: conditions and values need space delimiters, not colons]
 # Suffixed commentary
```

Render:

![image](https://github.com/user-attachments/assets/cf109fc6-8a3f-4558-9aa9-d381cc90ff41)
